### PR TITLE
refactor: reuse httpclient for online check

### DIFF
--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -4,6 +4,7 @@ using FlockForge.Core.Configuration;
 using FlockForge.Services.Firebase;
 using FlockForge.Services.Navigation;
 using CommunityToolkit.Maui;
+using System.Net.Http;
 
 #if IOS
 using FlockForge.Platforms.iOS.Services;
@@ -41,10 +42,11 @@ public static class MauiProgram
 			return config;
 		});
 		
-		// Platform services
-		builder.Services.AddSingleton<IConnectivity>(Connectivity.Current);
-		builder.Services.AddSingleton<ISecureStorage>(SecureStorage.Default);
-		builder.Services.AddSingleton<IPreferences>(Preferences.Default);
+                // Platform services
+                builder.Services.AddSingleton<IConnectivity>(Connectivity.Current);
+                builder.Services.AddSingleton<ISecureStorage>(SecureStorage.Default);
+                builder.Services.AddSingleton<IPreferences>(Preferences.Default);
+                builder.Services.AddSingleton<HttpClient>();
 		
 		// Firebase platform initializers
 #if IOS

--- a/Services/Firebase/IFirebaseService.cs
+++ b/Services/Firebase/IFirebaseService.cs
@@ -1,11 +1,12 @@
 using FlockForge.Models.Authentication;
+using System.Threading;
 
 namespace FlockForge.Services.Firebase;
 
 public interface IFirebaseService
 {
     Task<bool> IsAuthenticatedAsync();
-    Task<bool> IsOnlineAsync();
+    Task<bool> IsOnlineAsync(CancellationToken cancellationToken = default);
     Task<AuthResult> AuthenticateAsync(string email, string password);
     Task<AuthResult> AuthenticateWithGoogleAsync();
     Task<AuthResult> RegisterAsync(string email, string password, string displayName);


### PR DESCRIPTION
## Summary
- register a singleton `HttpClient` in `MauiProgram`
- inject `HttpClient` into `FirebaseService` and add cancellation/backoff to `IsOnlineAsync`
- expose optional `CancellationToken` on `IFirebaseService.IsOnlineAsync`

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689329e7b054832ea960b1cdc88db0d5