### PR TITLE
Fix iOS observer disposal warnings

### DIFF
--- a/Utilities/Disposal/ObserverTracker.cs
+++ b/Utilities/Disposal/ObserverTracker.cs
@@ -1,0 +1,19 @@
+#if DEBUG
+using System;
+using System.Runtime.CompilerServices;
+
+namespace FlockForge.Utilities.Disposal
+{
+    static class ObserverTracker
+    {
+        static readonly ConditionalWeakTable<IDisposable, string> Notes = new();
+
+        public static T Mark<T>(T d, [CallerFilePath] string f = "", [CallerLineNumber] int l = 0)
+            where T : class, IDisposable
+        {
+            Notes.Add(d, $"{System.IO.Path.GetFileName(f)}:{l}");
+            return d;
+        }
+    }
+}
+#endif

--- a/docs/ios-lifecycle.md
+++ b/docs/ios-lifecycle.md
@@ -3,3 +3,4 @@
 - Subscribe to observers and Rx streams in `OnAppearing` and dispose in `OnDisappearing`.
 - Pages inheriting from `DisposableContentPage` get a `CompositeDisposable` that is cleared on disappearance; debug builds can wrap tokens with `DisposeTracker`.
 - If a page uses `WebView`, call `DisposableContentPage.StopWebView` in `OnDisappearing` to stop loading and clear its source.
+- Service-level and AppDelegate observers should be stored in fields and disposed in `Dispose(bool)` to avoid "observer object was not disposed" warnings.


### PR DESCRIPTION
## Summary
- store iOS notification observers in AppDelegate fields and dispose in `Dispose`
- manage AppShell auth subscription and navigation hooks with `CompositeDisposable`
- add debug-only `ObserverTracker` and document observer lifecycle

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_689b0b251dcc832ea8384816c870697f