### PR TITLE
Add explicit debug tracking for iOS observers

### DIFF
--- a/Platforms/iOS/AppDelegate.cs
+++ b/Platforms/iOS/AppDelegate.cs
@@ -105,7 +105,8 @@ public class AppDelegate : MauiUIApplicationDelegate
             _memoryWarningObserver = ObserverTracker.Mark(
                 NSNotificationCenter.DefaultCenter.AddObserver(
                     UIApplication.DidReceiveMemoryWarningNotification,
-                    HandleMemoryWarning));
+                    HandleMemoryWarning),
+                "AppDelegate.cs:SetupMemoryManagement");
 #else
             _memoryWarningObserver = NSNotificationCenter.DefaultCenter.AddObserver(
                 UIApplication.DidReceiveMemoryWarningNotification,
@@ -117,7 +118,8 @@ public class AppDelegate : MauiUIApplicationDelegate
             _didEnterBackgroundObserver = ObserverTracker.Mark(
                 NSNotificationCenter.DefaultCenter.AddObserver(
                     UIApplication.DidEnterBackgroundNotification,
-                    HandleDidEnterBackground));
+                    HandleDidEnterBackground),
+                "AppDelegate.cs:SetupMemoryManagement");
 #else
             _didEnterBackgroundObserver = NSNotificationCenter.DefaultCenter.AddObserver(
                 UIApplication.DidEnterBackgroundNotification,
@@ -128,7 +130,8 @@ public class AppDelegate : MauiUIApplicationDelegate
             _willEnterForegroundObserver = ObserverTracker.Mark(
                 NSNotificationCenter.DefaultCenter.AddObserver(
                     UIApplication.WillEnterForegroundNotification,
-                    HandleWillEnterForeground));
+                    HandleWillEnterForeground),
+                "AppDelegate.cs:SetupMemoryManagement");
 #else
             _willEnterForegroundObserver = NSNotificationCenter.DefaultCenter.AddObserver(
                 UIApplication.WillEnterForegroundNotification,

--- a/Utilities/Disposal/ObserverTracker.cs
+++ b/Utilities/Disposal/ObserverTracker.cs
@@ -1,5 +1,6 @@
 #if DEBUG
 using System;
+using System.Runtime.CompilerServices;
 namespace FlockForge.Utilities.Disposal
 {
     static class ObserverTracker

--- a/Utilities/Disposal/ObserverTracker.cs
+++ b/Utilities/Disposal/ObserverTracker.cs
@@ -1,17 +1,15 @@
 #if DEBUG
 using System;
-using System.Runtime.CompilerServices;
-
 namespace FlockForge.Utilities.Disposal
 {
     static class ObserverTracker
     {
         static readonly ConditionalWeakTable<IDisposable, string> Notes = new();
 
-        public static T Mark<T>(T d, [CallerFilePath] string f = "", [CallerLineNumber] int l = 0)
+        public static T Mark<T>(T d, string site)
             where T : class, IDisposable
         {
-            Notes.Add(d, $"{System.IO.Path.GetFileName(f)}:{l}");
+            Notes.Add(d, site);
             return d;
         }
     }


### PR DESCRIPTION
## Summary
- tag iOS AddObserver subscriptions with `ObserverTracker.Mark(token, "AppDelegate.cs:SetupMemoryManagement")`
- extend `ObserverTracker.Mark` to accept descriptive call-site notes for leak debugging

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689b441555a8832e8eff044eb3508e23