### PR TITLE
feat: verify fonts and add android fallback

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -8,6 +8,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Resources/Styles/Colors.xaml" />
                 <ResourceDictionary Source="Resources/Styles/Styles.xaml" />
+                <ResourceDictionary Source="Resources/Styles/Fonts.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/FlockForge.csproj
+++ b/FlockForge.csproj
@@ -196,13 +196,18 @@
 
 		<!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
 		<MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
-	</ItemGroup>
+</ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
-		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
+<ItemGroup>
+<MauiFont Include="Resources/Fonts/OpenSans-Regular.ttf" Alias="OpenSansRegular" />
+<MauiFont Include="Resources/Fonts/OpenSans-Semibold.ttf" Alias="OpenSansSemibold" />
+</ItemGroup>
+
+<ItemGroup>
+<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
+<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+<PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
 		
 		<!-- Platform-specific Firebase packages to avoid Crashlytics conflicts -->
 		<!-- iOS: Complete package for framework dependencies -->
@@ -226,10 +231,25 @@
 		<GoogleServicesJson Include="Platforms\Android\google-services.json" />
 	</ItemGroup>
 
-	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
-		<BundleResource Include="Platforms\iOS\GoogleService-Info.plist">
-			<LogicalName>GoogleService-Info.plist</LogicalName>
-		</BundleResource>
-	</ItemGroup>
+<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
+<BundleResource Include="Platforms\iOS\GoogleService-Info.plist">
+<LogicalName>GoogleService-Info.plist</LogicalName>
+</BundleResource>
+</ItemGroup>
+
+<PropertyGroup>
+<PowerShellExe Condition="'$(OS)' == 'Windows_NT' and '$(PowerShellExe)' == ''">powershell</PowerShellExe>
+<PowerShellExe Condition="'$(OS)' != 'Windows_NT' and '$(PowerShellExe)' == ''">pwsh</PowerShellExe>
+</PropertyGroup>
+
+<Target Name="VerifyFonts" BeforeTargets="Build">
+<Exec
+Command="&quot;$(PowerShellExe)&quot; -NoProfile -ExecutionPolicy Bypass -File &quot;$([System.IO.Path]::Combine('$(MSBuildProjectDirectory)','build','scripts','verify-fonts.ps1'))&quot; -Project &quot;$(MSBuildProjectFullPath)&quot; -TargetFramework &quot;$(TargetFramework)&quot; -Configuration &quot;$(Configuration)&quot;"
+IgnoreExitCode="true">
+<Output TaskParameter="ExitCode" PropertyName="VerifyFontsExitCode" />
+</Exec>
+<Warning Condition="'$(VerifyFontsExitCode)' == '2'" Text="verify-fonts reported warnings (non-blocking). See details above." />
+<Error   Condition="'$(VerifyFontsExitCode)' == '1'" Text="verify-fonts reported errors. See details above." />
+</Target>
 
 </Project>

--- a/Resources/Styles/Fonts.xaml
+++ b/Resources/Styles/Fonts.xaml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+
+  <!-- Default app font alias (DynamicResource so Android can switch to fallback at runtime if needed).
+       If iOS previously needed a different name, set that via OnPlatform below. -->
+  <x:String x:Key="AppFontFamily">OpenSansRegular</x:String>
+
+  <!-- Example: base Label font using the DynamicResource so fallback works without restyling views -->
+  <Style TargetType="Label" x:Key="BaseLabel">
+    <Setter Property="FontFamily" Value="{DynamicResource AppFontFamily}" />
+    <Setter Property="FontSize" Value="14" />
+  </Style>
+
+  <!-- If iOS historically needed a different family name, preserve it via OnPlatform for the AppFontFamily key:
+  <OnPlatform x:Key="AppFontFamily" x:TypeArguments="x:String"
+              iOS="OpenSansRegular"
+              Android="OpenSansRegular"
+              MacCatalyst="OpenSansRegular"
+              WinUI="OpenSansRegular" />
+  -->
+</ResourceDictionary>

--- a/Resources/Styles/Styles.xaml
+++ b/Resources/Styles/Styles.xaml
@@ -26,7 +26,7 @@
     <Style TargetType="Button">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource PrimaryDarkText}}" />
         <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
-        <Setter Property="FontFamily" Value="OpenSansRegular"/>
+        <Setter Property="FontFamily" Value="{DynamicResource AppFontFamily}"/>
         <Setter Property="FontSize" Value="14"/>
         <Setter Property="BorderWidth" Value="0"/>
         <Setter Property="CornerRadius" Value="8"/>
@@ -70,7 +70,7 @@
     <Style TargetType="DatePicker">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource White}}" />
         <Setter Property="BackgroundColor" Value="Transparent" />
-        <Setter Property="FontFamily" Value="OpenSansRegular"/>
+        <Setter Property="FontFamily" Value="{DynamicResource AppFontFamily}"/>
         <Setter Property="FontSize" Value="14"/>
         <Setter Property="MinimumHeightRequest" Value="44"/>
         <Setter Property="MinimumWidthRequest" Value="44"/>
@@ -91,7 +91,7 @@
     <Style TargetType="Editor">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
         <Setter Property="BackgroundColor" Value="Transparent" />
-        <Setter Property="FontFamily" Value="OpenSansRegular"/>
+        <Setter Property="FontFamily" Value="{DynamicResource AppFontFamily}"/>
         <Setter Property="FontSize" Value="14" />
         <Setter Property="PlaceholderColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray500}}" />
         <Setter Property="MinimumHeightRequest" Value="44"/>
@@ -113,7 +113,7 @@
     <Style TargetType="Entry">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
         <Setter Property="BackgroundColor" Value="Transparent" />
-        <Setter Property="FontFamily" Value="OpenSansRegular"/>
+        <Setter Property="FontFamily" Value="{DynamicResource AppFontFamily}"/>
         <Setter Property="FontSize" Value="14" />
         <Setter Property="PlaceholderColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray500}}" />
         <Setter Property="MinimumHeightRequest" Value="44"/>
@@ -164,7 +164,7 @@
     <Style TargetType="Label">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
         <Setter Property="BackgroundColor" Value="Transparent" />
-        <Setter Property="FontFamily" Value="OpenSansRegular" />
+        <Setter Property="FontFamily" Value="{DynamicResource AppFontFamily}" />
         <Setter Property="FontSize" Value="14" />
         <Setter Property="VisualStateManager.VisualStateGroups">
             <VisualStateGroupList>
@@ -207,7 +207,7 @@
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource White}}" />
         <Setter Property="TitleColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray200}}" />
         <Setter Property="BackgroundColor" Value="Transparent" />
-        <Setter Property="FontFamily" Value="OpenSansRegular"/>
+        <Setter Property="FontFamily" Value="{DynamicResource AppFontFamily}"/>
         <Setter Property="FontSize" Value="14" />
         <Setter Property="MinimumHeightRequest" Value="44"/>
         <Setter Property="MinimumWidthRequest" Value="44"/>
@@ -245,7 +245,7 @@
     <Style TargetType="RadioButton">
         <Setter Property="BackgroundColor" Value="Transparent"/>
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
-        <Setter Property="FontFamily" Value="OpenSansRegular"/>
+        <Setter Property="FontFamily" Value="{DynamicResource AppFontFamily}"/>
         <Setter Property="FontSize" Value="14"/>
         <Setter Property="MinimumHeightRequest" Value="44"/>
         <Setter Property="MinimumWidthRequest" Value="44"/>
@@ -272,7 +272,7 @@
         <Setter Property="PlaceholderColor" Value="{StaticResource Gray500}" />
         <Setter Property="CancelButtonColor" Value="{StaticResource Gray500}" />
         <Setter Property="BackgroundColor" Value="Transparent" />
-        <Setter Property="FontFamily" Value="OpenSansRegular" />
+        <Setter Property="FontFamily" Value="{DynamicResource AppFontFamily}" />
         <Setter Property="FontSize" Value="14" />
         <Setter Property="MinimumHeightRequest" Value="44"/>
         <Setter Property="MinimumWidthRequest" Value="44"/>
@@ -295,7 +295,7 @@
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource White}}" />
         <Setter Property="PlaceholderColor" Value="{StaticResource Gray500}" />
         <Setter Property="BackgroundColor" Value="Transparent" />
-        <Setter Property="FontFamily" Value="OpenSansRegular" />
+        <Setter Property="FontFamily" Value="{DynamicResource AppFontFamily}" />
         <Setter Property="FontSize" Value="14" />
         <Setter Property="VisualStateManager.VisualStateGroups">
             <VisualStateGroupList>
@@ -375,7 +375,7 @@
     <Style TargetType="TimePicker">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource White}}" />
         <Setter Property="BackgroundColor" Value="Transparent"/>
-        <Setter Property="FontFamily" Value="OpenSansRegular"/>
+        <Setter Property="FontFamily" Value="{DynamicResource AppFontFamily}"/>
         <Setter Property="FontSize" Value="14"/>
         <Setter Property="MinimumHeightRequest" Value="44"/>
         <Setter Property="MinimumWidthRequest" Value="44"/>

--- a/build/scripts/verify-fonts.ps1
+++ b/build/scripts/verify-fonts.ps1
@@ -1,0 +1,140 @@
+#Requires -Version 3.0
+<#
+Exit codes:
+  0 = success
+  1 = error (missing file, duplicate alias, unreadable/invalid font file, or TreatWarningsAsErrors)
+  2 = success with warnings (e.g., undeclared FontFamily usages)
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory=$true)][string]$Project,
+  [Parameter()][string]$TargetFramework,
+  [Parameter()][string]$Configuration,
+  [switch]$TreatWarningsAsErrors
+)
+
+function Resolve-AbsolutePath([string]$BaseDir, [string]$RelativePath) {
+  $rp = $RelativePath -replace '\\','/'  # tolerate mixed input
+  return [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($BaseDir, $rp))
+}
+
+function Test-FontMagicBytes([string]$Path) {
+  try {
+    $fs = [System.IO.File]::Open($Path, 'Open', 'Read', 'ReadWrite')
+    try {
+      $buf = New-Object byte[] 4
+      $read = $fs.Read($buf, 0, 4)
+      if ($read -ne 4) { return $false }
+      # Check for 00 01 00 00 (0x00010000)
+      $val = [System.BitConverter]::ToUInt32(($buf[3],$buf[2],$buf[1],$buf[0]), 0) # big-endian interpret
+      if ($val -eq 0x00010000) { return $true }
+      # Check for ASCII 'OTTO', 'true', 'typ1'
+      $str = [System.Text.Encoding]::ASCII.GetString($buf)
+      if ($str -eq 'OTTO' -or $str -eq 'true' -or $str -eq 'typ1') { return $true }
+      return $false
+    } finally { $fs.Dispose() }
+  } catch {
+    return $false
+  }
+}
+
+if (!(Test-Path -LiteralPath $Project)) {
+  Write-Error "verify-fonts.ps1: Project file not found: $Project"
+  exit 1
+}
+
+try {
+  [xml]$xml = Get-Content -LiteralPath $Project
+} catch {
+  Write-Error "verify-fonts.ps1: Failed to read project XML: $($_.Exception.Message)"
+  exit 1
+}
+
+# Collect <MauiFont Include="..."> and their Alias attributes
+$mauiFonts = @()
+$nodes = $xml.Project.ItemGroup | ForEach-Object { $_.MauiFont } | Where-Object { $_ -ne $null }
+foreach ($n in $nodes) {
+  $include = $n.Include
+  $alias   = $n.Alias
+  if ([string]::IsNullOrWhiteSpace($include) -or [string]::IsNullOrWhiteSpace($alias)) {
+    Write-Error "verify-fonts.ps1: Found a <MauiFont> missing Include or Alias."
+    exit 1
+  }
+  $mauiFonts += [pscustomobject]@{ Include=$include; Alias=$alias }
+}
+
+if ($mauiFonts.Count -eq 0) {
+  Write-Error "verify-fonts.ps1: No <MauiFont> entries found. At least one font must be declared."
+  exit 1
+}
+
+# Check duplicates in Alias
+$dupes = $mauiFonts | Group-Object Alias | Where-Object { $_.Count -gt 1 }
+if ($dupes) {
+  $dupeList = ($dupes | ForEach-Object { "$( $_.Name) x$( $_.Count)" }) -join ', '
+  Write-Error "verify-fonts.ps1: Duplicate Alias detected: $dupeList"
+  exit 1
+}
+
+$projDir = [System.IO.Path]::GetDirectoryName([System.IO.Path]::GetFullPath($Project))
+$missing = @()
+$invalid = @()
+foreach ($f in $mauiFonts) {
+  $abs = Resolve-AbsolutePath $projDir $f.Include
+  if (!(Test-Path -LiteralPath $abs)) {
+    $missing += "$( $f.Include) (Alias=$( $f.Alias))"
+    continue
+  }
+  if (-not (Test-FontMagicBytes -Path $abs)) {
+    $invalid += "$( $f.Include) (Alias=$( $f.Alias))"
+  }
+}
+
+if ($missing.Count -gt 0) {
+  Write-Error "verify-fonts.ps1: Missing font files: $( $missing -join '; ')"
+  exit 1
+}
+if ($invalid.Count -gt 0) {
+  Write-Error "verify-fonts.ps1: Invalid or unreadable font files (expect TTF/OTF): $( $invalid -join '; ')"
+  exit 1
+}
+
+# Soft check: find FontFamily uses not in alias set (warn only by default)
+$aliases = $mauiFonts.Alias
+$repoRoot = $projDir
+$warns = @()
+
+$files = Get-ChildItem -LiteralPath $repoRoot -Recurse -Include *.xaml,*.cs -File -ErrorAction SilentlyContinue
+foreach ($file in $files) {
+  $content = Get-Content -LiteralPath $file.FullName -Raw
+  # XAML: FontFamily="Name" (static string only)
+  $matches = Select-String -InputObject $content -Pattern 'FontFamily\s*=\s*"([^"]+)"' -AllMatches
+  foreach ($m in $matches.Matches) {
+    $name = $m.Groups[1].Value
+    if ($aliases -notcontains $name) {
+      $warns += "$( $file.FullName): $name"
+    }
+  }
+  # C#: new FontFamily("Name") or WithFont("Name") simple cases
+  $matchesCs = Select-String -InputObject $content -Pattern 'FontFamily\(\s*"([^"]+)"\s*\)|WithFont\(\s*"([^"]+)"\s*\)' -AllMatches
+  foreach ($m in $matchesCs.Matches) {
+    $name = ($m.Groups[1].Value, $m.Groups[2].Value) | Where-Object { $_ -ne "" } | Select-Object -First 1
+    if ($name -and ($aliases -notcontains $name)) {
+      $warns += "$( $file.FullName): $name"
+    }
+  }
+}
+
+if ($warns.Count -gt 0) {
+  Write-Warning "verify-fonts.ps1: Found FontFamily values not declared as MAUI aliases:"
+  $warns | ForEach-Object { Write-Warning "  $_" }
+  if ($TreatWarningsAsErrors) {
+    Write-Error "verify-fonts.ps1: TreatWarningsAsErrors is set; failing due to warnings."
+    exit 1
+  } else {
+    exit 2
+  }
+}
+
+Write-Host "verify-fonts.ps1: Fonts OK ($($mauiFonts.Count) declared)."
+exit 0


### PR DESCRIPTION
## Summary
- declare OpenSans fonts and run cross-platform PowerShell verification before builds
- expose dynamic AppFontFamily resource with runtime Android fallback
- add verify-fonts.ps1 build script

## Testing
- `dotnet clean FlockForge.csproj` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ca57e8c50832e81c583c51b57d163