### PR TITLE
Remove duplicate OpenSans font registration

### DIFF
--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -26,12 +26,7 @@ public static class MauiProgram
 		var builder = MauiApp.CreateBuilder();
                 builder
                         .UseMauiApp<App>()
-                        .UseMauiCommunityToolkit()
-                        .ConfigureFonts(fonts =>
-                        {
-                                fonts.AddFont("OpenSans-Regular.ttf", FontNames.Regular);
-                                fonts.AddFont("OpenSans-Semibold.ttf", FontNames.Semibold);
-                        });
+                        .UseMauiCommunityToolkit();
 
 		// Configuration
 		builder.Services.AddSingleton<FirebaseConfig>(sp =>


### PR DESCRIPTION
## Summary
- rely solely on MAUI font pipeline by removing runtime `AddFont` calls for OpenSans

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_689daea82a40832ea7cb6208408650ea