### PR TITLE
fix(android): restore MAUI font alias mapping at runtime to prevent OpenSans crash

### DIFF
--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -28,10 +28,20 @@ public static class MauiProgram
                         .UseMauiApp<App>()
                         .UseMauiCommunityToolkit();
 
-		// Configuration
-		builder.Services.AddSingleton<FirebaseConfig>(sp =>
-		{
-			var config = new FirebaseConfig();
+#if ANDROID
+                builder.ConfigureFonts(fonts =>
+                {
+                        // Re-register the same files/aliases to ensure Android alias→asset mapping is present at runtime.
+                        // Use file names (not paths); build packs them from Resources/Fonts.
+                        fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
+                        fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
+                });
+#endif
+
+                // Configuration
+                builder.Services.AddSingleton<FirebaseConfig>(sp =>
+                {
+                        var config = new FirebaseConfig();
 			// Load from appsettings.json or platform config
 			return config;
 		});


### PR DESCRIPTION
## Summary
- re-register OpenSans font aliases on Android at runtime to ensure FontManager resolves them

## Testing
- `dotnet clean` *(fails: command not found)*
- `adb uninstall io.nexair.flockforge` *(fails: command not found)*
- `adb shell run-as io.nexair.flockforge rm -rf /data/data/io.nexair.flockforge/files/.__override__` *(fails: command not found)*
- `dotnet build -f net9.0-android` *(fails: command not found)*
- `dotnet build -t:Run -f net9.0-android` *(fails: command not found)*
- `adb shell pm path io.nexair.flockforge | sed -n 's/package://p' | while read p; do adb shell unzip -l "$p" | grep -i -E 'open.?sans|fonts/.+open'; done` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f4650dbe4832e960be8d72ca8994e