### PR TITLE
Refactor navigation with flyout and dashboard

### DIFF
--- a/AppShell.xaml
+++ b/AppShell.xaml
@@ -38,7 +38,7 @@
             </Tab.Icon>
             <ShellContent
                 Title="Farms"
-                ContentTemplate="{DataTemplate local:MainPage}"
+                ContentTemplate="{DataTemplate pages:FarmsPage}"
                 Route="farms" />
         </Tab>
 
@@ -48,20 +48,26 @@
             </Tab.Icon>
             <ShellContent
                 Title="Reports"
-                ContentTemplate="{DataTemplate local:MainPage}"
+                ContentTemplate="{DataTemplate pages:ReportsPage}"
                 Route="reports" />
         </Tab>
-
-        <Tab Title="Settings">
-            <Tab.Icon>
-                <FontImageSource Glyph="⚙" Size="24" />
-            </Tab.Icon>
-            <ShellContent
-                Title="Settings"
-                ContentTemplate="{DataTemplate local:MainPage}"
-                Route="settings" />
-        </Tab>
     </TabBar>
+
+    <!-- Flyout menu for secondary items -->
+    <FlyoutItem Title="Profile" Route="profile">
+        <ShellContent ContentTemplate="{DataTemplate pages:ProfilePage}" />
+    </FlyoutItem>
+
+    <FlyoutItem Title="Settings" Route="settings">
+        <ShellContent ContentTemplate="{DataTemplate pages:SettingsPage}" />
+    </FlyoutItem>
+
+    <!-- Hidden route for groups -->
+    <ShellContent
+        Title="Groups"
+        ContentTemplate="{DataTemplate pages:GroupsPage}"
+        Route="groups"
+        IsVisible="False" />
     
     <!-- Debug-only content (can be toggled via IsVisible in code-behind if needed) -->
     <ShellContent

--- a/AppShell.xaml.cs
+++ b/AppShell.xaml.cs
@@ -124,7 +124,7 @@ public partial class AppShell : Shell
             if (MainTabBar != null) MainTabBar.IsVisible = true;
             else _logger.LogWarning("MainTabBar is null in ShowMainApplication");
 
-            FlyoutBehavior = FlyoutBehavior.Disabled;
+            FlyoutBehavior = FlyoutBehavior.Flyout;
 
             MainThread.BeginInvokeOnMainThread(async () =>
             {

--- a/MainPage.xaml
+++ b/MainPage.xaml
@@ -1,19 +1,36 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="FlockForge.MainPage">
+             xmlns:services="clr-namespace:FlockForge.Services"
+             x:Class="FlockForge.MainPage"
+             Title="Dashboard">
+    <Grid Style="{StaticResource GF.Grid}" RowDefinitions="Auto,*">
+        <!-- Header -->
+        <Grid ColumnDefinitions="Auto,*,Auto" Grid.Row="0">
+            <Label Text="Farm: Demo" Style="{StaticResource GF.LabelBase}" VerticalOptions="Center" />
+            <Label Grid.Column="1"
+                   Text="{Binding Source={x:Static services:AppStatusService.Instance}, Path=SyncLabel}"
+                   Style="{StaticResource GF.LabelBase}"
+                   HorizontalOptions="Center"
+                   VerticalOptions="Center" />
+            <Image Grid.Column="2" Source="flockforge_logo.png" HeightRequest="40" WidthRequest="40" />
+        </Grid>
 
-    <Grid Style="{StaticResource GF.Grid}">
-        <VerticalStackLayout Spacing="{DynamicResource GF.Spacing}">
-            <Label Text="Hello, World!" Style="{StaticResource GF.LabelBase}" />
-            <Label Text="Welcome to .NET Multi-platform App UI"
-                   Style="{StaticResource GF.LabelBase}" />
-            <Button x:Name="CounterBtn"
-                    Text="Click me"
-                    SemanticProperties.Hint="Counts the number of times you click"
-                    Clicked="OnCounterClicked"
-                    Style="{StaticResource GF.ButtonBase}" />
-        </VerticalStackLayout>
+        <!-- Dashboard cards -->
+        <Grid Grid.Row="1" RowSpacing="{DynamicResource GF.Spacing}" ColumnSpacing="{DynamicResource GF.Spacing}">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <Button Grid.Row="0" Grid.Column="0" Text="Profile" Style="{StaticResource GF.Tile}" Clicked="OnProfileTapped" />
+            <Button Grid.Row="0" Grid.Column="1" Text="Farm Management" Style="{StaticResource GF.Tile}" Clicked="OnFarmManagementTapped" />
+            <Button Grid.Row="1" Grid.Column="0" Text="Groups" Style="{StaticResource GF.Tile}" Clicked="OnGroupsTapped" />
+            <Button Grid.Row="1" Grid.Column="1" Text="Reports" Style="{StaticResource GF.Tile}" Clicked="OnReportsTapped" />
+        </Grid>
     </Grid>
-
 </ContentPage>

--- a/MainPage.xaml.cs
+++ b/MainPage.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reactive.Disposables;
+using Microsoft.Maui.Controls;
 
 namespace FlockForge;
 
@@ -7,24 +8,23 @@ public partial class MainPage : ContentPage, IDisposable
 {
     private readonly CompositeDisposable _disposables = new();
     private bool _disposed;
-    private int count = 0;
 
     public MainPage()
     {
         InitializeComponent();
     }
 
-    private void OnCounterClicked(object? sender, EventArgs e)
-    {
-        count++;
+    private async void OnProfileTapped(object? sender, EventArgs e) =>
+        await Shell.Current.GoToAsync("profile");
 
-        if (count == 1)
-            CounterBtn.Text = $"Clicked {count} time";
-        else
-            CounterBtn.Text = $"Clicked {count} times";
+    private async void OnFarmManagementTapped(object? sender, EventArgs e) =>
+        await Shell.Current.GoToAsync("farms");
 
-        SemanticScreenReader.Announce(CounterBtn.Text);
-    }
+    private async void OnGroupsTapped(object? sender, EventArgs e) =>
+        await Shell.Current.GoToAsync("groups");
+
+    private async void OnReportsTapped(object? sender, EventArgs e) =>
+        await Shell.Current.GoToAsync("reports");
 
     protected override void OnDisappearing()
     {

--- a/Views/Pages/FarmsPage.xaml
+++ b/Views/Pages/FarmsPage.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="FlockForge.Views.Pages.FarmsPage"
+             Title="Farms">
+    <Grid Style="{StaticResource GF.Grid}">
+        <Label Text="Farms Page" Style="{StaticResource GF.LabelBase}" />
+    </Grid>
+</ContentPage>

--- a/Views/Pages/FarmsPage.xaml.cs
+++ b/Views/Pages/FarmsPage.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.Maui.Controls;
+
+namespace FlockForge.Views.Pages;
+
+public partial class FarmsPage : ContentPage
+{
+    public FarmsPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/Views/Pages/GroupsPage.xaml
+++ b/Views/Pages/GroupsPage.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="FlockForge.Views.Pages.GroupsPage"
+             Title="Groups">
+    <Grid Style="{StaticResource GF.Grid}">
+        <Label Text="Groups Page" Style="{StaticResource GF.LabelBase}" />
+    </Grid>
+</ContentPage>

--- a/Views/Pages/GroupsPage.xaml.cs
+++ b/Views/Pages/GroupsPage.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.Maui.Controls;
+
+namespace FlockForge.Views.Pages;
+
+public partial class GroupsPage : ContentPage
+{
+    public GroupsPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/Views/Pages/ProfilePage.xaml
+++ b/Views/Pages/ProfilePage.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="FlockForge.Views.Pages.ProfilePage"
+             Title="Profile">
+    <Grid Style="{StaticResource GF.Grid}">
+        <Label Text="Profile Page" Style="{StaticResource GF.LabelBase}" />
+    </Grid>
+</ContentPage>

--- a/Views/Pages/ProfilePage.xaml.cs
+++ b/Views/Pages/ProfilePage.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.Maui.Controls;
+
+namespace FlockForge.Views.Pages;
+
+public partial class ProfilePage : ContentPage
+{
+    public ProfilePage()
+    {
+        InitializeComponent();
+    }
+}

--- a/Views/Pages/ReportsPage.xaml
+++ b/Views/Pages/ReportsPage.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="FlockForge.Views.Pages.ReportsPage"
+             Title="Reports">
+    <Grid Style="{StaticResource GF.Grid}">
+        <Label Text="Reports Page" Style="{StaticResource GF.LabelBase}" />
+    </Grid>
+</ContentPage>

--- a/Views/Pages/ReportsPage.xaml.cs
+++ b/Views/Pages/ReportsPage.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.Maui.Controls;
+
+namespace FlockForge.Views.Pages;
+
+public partial class ReportsPage : ContentPage
+{
+    public ReportsPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/Views/Pages/SettingsPage.xaml
+++ b/Views/Pages/SettingsPage.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="FlockForge.Views.Pages.SettingsPage"
+             Title="Settings">
+    <Grid Style="{StaticResource GF.Grid}">
+        <Label Text="Settings Page" Style="{StaticResource GF.LabelBase}" />
+    </Grid>
+</ContentPage>

--- a/Views/Pages/SettingsPage.xaml.cs
+++ b/Views/Pages/SettingsPage.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.Maui.Controls;
+
+namespace FlockForge.Views.Pages;
+
+public partial class SettingsPage : ContentPage
+{
+    public SettingsPage()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
## Summary
- add flyout items for profile and settings while keeping dashboard, farms, and reports in the bottom tab bar
- replace MainPage with a card-based dashboard featuring a farm header and links to key modules
- create placeholder pages for profile, farms, groups, reports, and settings; enable flyout navigation at runtime

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a46d98f31c832e81eb0de9228b1bc6