### PR TITLE
Refactor navigation with flyout and dashboard

### DIFF
--- a/AppShell.xaml
+++ b/AppShell.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <Shell
     x:Class="FlockForge.AppShell"
+    x:Name="AppShell"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:local="clr-namespace:FlockForge"
@@ -13,15 +14,17 @@
     <ShellContent
         x:Name="LoginPage"
         ContentTemplate="{DataTemplate pages:LoginPage}"
-        Route="login" />
-        
+        Route="login"
+        Shell.FlyoutItemIsVisible="False" />
+
     <ShellContent
         x:Name="RegisterPage"
         ContentTemplate="{DataTemplate pages:RegisterPage}"
-        Route="register" />
+        Route="register"
+        Shell.FlyoutItemIsVisible="False" />
     
     <!-- Main Application Content (protected by authentication) -->
-    <TabBar x:Name="MainTabBar" IsVisible="False">
+    <TabBar x:Name="MainTabBar" IsVisible="False" Title="Home">
         <Tab Title="Dashboard">
             <Tab.Icon>
                 <FontImageSource Glyph="🏠" Size="24" />
@@ -38,30 +41,26 @@
             </Tab.Icon>
             <ShellContent
                 Title="Farms"
-                ContentTemplate="{DataTemplate local:MainPage}"
+                ContentTemplate="{DataTemplate pages:FarmsPage}"
                 Route="farms" />
         </Tab>
-
-        <Tab Title="Reports">
-            <Tab.Icon>
-                <FontImageSource Glyph="📊" Size="24" />
-            </Tab.Icon>
-            <ShellContent
-                Title="Reports"
-                ContentTemplate="{DataTemplate local:MainPage}"
-                Route="reports" />
-        </Tab>
-
-        <Tab Title="Settings">
-            <Tab.Icon>
-                <FontImageSource Glyph="⚙" Size="24" />
-            </Tab.Icon>
-            <ShellContent
-                Title="Settings"
-                ContentTemplate="{DataTemplate local:MainPage}"
-                Route="settings" />
-        </Tab>
     </TabBar>
+
+    <!-- Flyout menu for secondary items -->
+    <MenuItem Text="Profile"
+              Command="{Binding Source={x:Reference AppShell}, Path=GoToCommand}"
+              CommandParameter="profile" />
+
+    <MenuItem Text="Settings"
+              Command="{Binding Source={x:Reference AppShell}, Path=GoToCommand}"
+              CommandParameter="settings" />
+
+    <!-- Hidden route for groups -->
+    <ShellContent
+        Title="Groups"
+        ContentTemplate="{DataTemplate pages:GroupsPage}"
+        Route="groups"
+        IsVisible="False" />
     
     <!-- Debug-only content (can be toggled via IsVisible in code-behind if needed) -->
     <ShellContent

--- a/AppShell.xaml.cs
+++ b/AppShell.xaml.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Reactive.Disposables;
 using System.Threading.Tasks;
+using System.Windows.Input;
 using FlockForge.Core.Interfaces;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui;                    // HandlerChangingEventArgs
 using Microsoft.Maui.Controls;          // Shell, GoToAsync, events
 using Microsoft.Maui.ApplicationModel;  // MainThread
+using FlockForge.Views.Pages;
 
 namespace FlockForge;
 
@@ -17,12 +19,28 @@ public partial class AppShell : Shell
     private readonly CompositeDisposable _bag = new();
     private IDisposable? _authSub;
     private bool _loaded;
+    public ICommand GoToCommand { get; }
 
     public AppShell(IAuthenticationService authService, ILogger<AppShell> logger)
     {
+        GoToCommand = new Command<string>(async route =>
+        {
+            try
+            {
+                await GoToAsync(route);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed navigation to {Route}", route);
+            }
+        });
+
         InitializeComponent();
         _authService = authService;
         _logger = logger;
+
+        Routing.RegisterRoute("profile", typeof(ProfilePage));
+        Routing.RegisterRoute("settings", typeof(SettingsPage));
 
         // Wire events once
         Loaded += OnLoadedOnce;
@@ -124,7 +142,7 @@ public partial class AppShell : Shell
             if (MainTabBar != null) MainTabBar.IsVisible = true;
             else _logger.LogWarning("MainTabBar is null in ShowMainApplication");
 
-            FlyoutBehavior = FlyoutBehavior.Disabled;
+            FlyoutBehavior = FlyoutBehavior.Flyout;
 
             MainThread.BeginInvokeOnMainThread(async () =>
             {

--- a/MainPage.xaml
+++ b/MainPage.xaml
@@ -1,19 +1,35 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="FlockForge.MainPage">
+             xmlns:services="clr-namespace:FlockForge.Services"
+             x:Class="FlockForge.MainPage"
+             Title="Dashboard">
+    <Grid Style="{StaticResource GF.Grid}" RowDefinitions="Auto,*">
+        <!-- Header -->
+        <Grid Grid.Row="0" ColumnDefinitions="*,Auto,Auto">
+            <Label Text="Farm: Demo" Style="{StaticResource GF.LabelBase}" VerticalOptions="Center" />
+            <Label Grid.Column="1"
+                   Text="{Binding Source={x:Static services:AppStatusService.Instance}, Path=SyncLabel}"
+                   Style="{StaticResource GF.LabelBase}"
+                   HorizontalOptions="End"
+                   VerticalOptions="Center" />
+            <Image Grid.Column="2" Source="flockforge_logo.png" HeightRequest="24" WidthRequest="24" VerticalOptions="Center" HorizontalOptions="End" />
+        </Grid>
 
-    <Grid Style="{StaticResource GF.Grid}">
-        <VerticalStackLayout Spacing="{DynamicResource GF.Spacing}">
-            <Label Text="Hello, World!" Style="{StaticResource GF.LabelBase}" />
-            <Label Text="Welcome to .NET Multi-platform App UI"
-                   Style="{StaticResource GF.LabelBase}" />
-            <Button x:Name="CounterBtn"
-                    Text="Click me"
-                    SemanticProperties.Hint="Counts the number of times you click"
-                    Clicked="OnCounterClicked"
-                    Style="{StaticResource GF.ButtonBase}" />
-        </VerticalStackLayout>
+        <!-- Dashboard cards -->
+        <Grid Grid.Row="1" RowSpacing="{DynamicResource GF.Spacing}" ColumnSpacing="{DynamicResource GF.Spacing}">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <Button Grid.Row="0" Grid.Column="0" Text="Profile" Style="{StaticResource GF.Tile}" Clicked="OnProfileTapped" />
+            <Button Grid.Row="0" Grid.Column="1" Text="My Farms" Style="{StaticResource GF.Tile}" Clicked="OnMyFarmsTapped" />
+            <Button Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Text="Groups" Style="{StaticResource GF.Tile}" Clicked="OnGroupsTapped" />
+        </Grid>
     </Grid>
-
 </ContentPage>

--- a/MainPage.xaml.cs
+++ b/MainPage.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reactive.Disposables;
+using Microsoft.Maui.Controls;
 
 namespace FlockForge;
 
@@ -7,24 +8,20 @@ public partial class MainPage : ContentPage, IDisposable
 {
     private readonly CompositeDisposable _disposables = new();
     private bool _disposed;
-    private int count = 0;
 
     public MainPage()
     {
         InitializeComponent();
     }
 
-    private void OnCounterClicked(object? sender, EventArgs e)
-    {
-        count++;
+    private async void OnProfileTapped(object? sender, EventArgs e) =>
+        await Shell.Current.GoToAsync("profile");
 
-        if (count == 1)
-            CounterBtn.Text = $"Clicked {count} time";
-        else
-            CounterBtn.Text = $"Clicked {count} times";
+    private async void OnMyFarmsTapped(object? sender, EventArgs e) =>
+        await Shell.Current.GoToAsync("//farms");
 
-        SemanticScreenReader.Announce(CounterBtn.Text);
-    }
+    private async void OnGroupsTapped(object? sender, EventArgs e) =>
+        await Shell.Current.GoToAsync("groups");
 
     protected override void OnDisappearing()
     {

--- a/Resources/Styles/GloveFirst.xaml
+++ b/Resources/Styles/GloveFirst.xaml
@@ -161,15 +161,13 @@
         </HorizontalStackLayout>
 
         <!-- Fallback dock -->
-        <Grid ColumnDefinitions="*,*,*"
+        <Grid ColumnDefinitions="*,*"
               HeightRequest="72"
               IsVisible="{Binding Source={x:Static services:NavigationService.Instance}, Path=HasItems, Converter={StaticResource InvertedBool}}">
           <Button Style="{StaticResource GF.ButtonBase}" Text="Home"
                   Command="{Binding Source={x:Static services:NavigationService.Instance}, Path=GoHomeCommand}" />
           <Button Grid.Column="1" Style="{StaticResource GF.ButtonBase}" Text="Animals"
                   Command="{Binding Source={x:Static services:NavigationService.Instance}, Path=GoAnimalsCommand}" />
-          <Button Grid.Column="2" Style="{StaticResource GF.ButtonBase}" Text="Reports"
-                  Command="{Binding Source={x:Static services:NavigationService.Instance}, Path=GoReportsCommand}" />
         </Grid>
       </Grid>
     </Grid>

--- a/Services/NavigationService.cs
+++ b/Services/NavigationService.cs
@@ -15,7 +15,6 @@ public sealed class NavigationService : INotifyPropertyChanged
 
     public ICommand GoHomeCommand { get; }
     public ICommand GoAnimalsCommand { get; }
-    public ICommand GoReportsCommand { get; }
 
     bool _hasItems;
     public bool HasItems
@@ -28,7 +27,6 @@ public sealed class NavigationService : INotifyPropertyChanged
     {
         GoHomeCommand    = new Command(async () => { try { await Shell.Current.GoToAsync("//home");    } catch { /* no-op; optionally log */ } });
         GoAnimalsCommand = new Command(async () => { try { await Shell.Current.GoToAsync("//animals"); } catch { /* no-op; optionally log */ } });
-        GoReportsCommand = new Command(async () => { try { await Shell.Current.GoToAsync("//reports"); } catch { /* no-op; optionally log */ } });
 
         Items.CollectionChanged += (_, __) => HasItems = Items.Count > 0;
         HasItems = Items.Count > 0;

--- a/Views/Pages/FarmsPage.xaml
+++ b/Views/Pages/FarmsPage.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="FlockForge.Views.Pages.FarmsPage"
+             Title="Farms">
+    <Grid Style="{StaticResource GF.Grid}">
+        <Label Text="Farms Page" Style="{StaticResource GF.LabelBase}" />
+    </Grid>
+</ContentPage>

--- a/Views/Pages/FarmsPage.xaml.cs
+++ b/Views/Pages/FarmsPage.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.Maui.Controls;
+
+namespace FlockForge.Views.Pages;
+
+public partial class FarmsPage : ContentPage
+{
+    public FarmsPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/Views/Pages/GroupsPage.xaml
+++ b/Views/Pages/GroupsPage.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="FlockForge.Views.Pages.GroupsPage"
+             Title="Groups">
+    <Grid Style="{StaticResource GF.Grid}">
+        <Label Text="Groups Page" Style="{StaticResource GF.LabelBase}" />
+    </Grid>
+</ContentPage>

--- a/Views/Pages/GroupsPage.xaml.cs
+++ b/Views/Pages/GroupsPage.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.Maui.Controls;
+
+namespace FlockForge.Views.Pages;
+
+public partial class GroupsPage : ContentPage
+{
+    public GroupsPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/Views/Pages/ProfilePage.xaml
+++ b/Views/Pages/ProfilePage.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="FlockForge.Views.Pages.ProfilePage"
+             Title="Profile">
+    <Grid Style="{StaticResource GF.Grid}">
+        <Label Text="Profile Page" Style="{StaticResource GF.LabelBase}" />
+    </Grid>
+</ContentPage>

--- a/Views/Pages/ProfilePage.xaml.cs
+++ b/Views/Pages/ProfilePage.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.Maui.Controls;
+
+namespace FlockForge.Views.Pages;
+
+public partial class ProfilePage : ContentPage
+{
+    public ProfilePage()
+    {
+        InitializeComponent();
+    }
+}

--- a/Views/Pages/SettingsPage.xaml
+++ b/Views/Pages/SettingsPage.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="FlockForge.Views.Pages.SettingsPage"
+             Title="Settings">
+    <Grid Style="{StaticResource GF.Grid}">
+        <Label Text="Settings Page" Style="{StaticResource GF.LabelBase}" />
+    </Grid>
+</ContentPage>

--- a/Views/Pages/SettingsPage.xaml.cs
+++ b/Views/Pages/SettingsPage.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.Maui.Controls;
+
+namespace FlockForge.Views.Pages;
+
+public partial class SettingsPage : ContentPage
+{
+    public SettingsPage()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
## Summary
- remove reports module from navigation and dashboard
- replace header icon with app logo and shorten tile text to "My Farms"
- fix flyout navigation to use relative routes

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a46d98f31c832e81eb0de9228b1bc6