### PR TITLE
Register shell routes for feature navigation

### DIFF
--- a/AppShell.xaml
+++ b/AppShell.xaml
@@ -3,6 +3,7 @@
     x:Class="FlockForge.AppShell"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:maui="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:local="clr-namespace:FlockForge"
     xmlns:views="clr-namespace:FlockForge.Views.Pages"
     xmlns:debug="clr-namespace:FlockForge.Pages"
@@ -47,11 +48,11 @@
 
     <!-- Flyout menu for secondary items -->
     <MenuItem Text="Profile"
-              Command="{Binding Source={x:Reference shell}, Path=GoToCommand}"
+              Command="{Binding GoToCommand, Source={RelativeSource AncestorType={x:Type maui:Shell}}}"
               CommandParameter="/profile" />
 
     <MenuItem Text="Settings"
-              Command="{Binding Source={x:Reference shell}, Path=GoToCommand}"
+              Command="{Binding GoToCommand, Source={RelativeSource AncestorType={x:Type maui:Shell}}}"
               CommandParameter="/settings" />
 
     <!-- Hidden route for groups -->

--- a/AppShell.xaml.cs
+++ b/AppShell.xaml.cs
@@ -43,6 +43,13 @@ public partial class AppShell : Shell
         Routing.RegisterRoute("profile", typeof(ProfilePage));
         Routing.RegisterRoute("settings", typeof(SettingsPage));
         Routing.RegisterRoute("login", typeof(LoginPage));
+        Routing.RegisterRoute("farms", typeof(FarmsPage));
+        Routing.RegisterRoute("groups", typeof(GroupsPage));
+        Routing.RegisterRoute("breeding", typeof(BreedingPage));
+        Routing.RegisterRoute("scanning", typeof(ScanningPage));
+        Routing.RegisterRoute("lambing", typeof(LambingPage));
+        Routing.RegisterRoute("weaning", typeof(WeaningPage));
+        Routing.RegisterRoute("reports", typeof(ReportsPage));
 
         // Wire events once
         Loaded += OnLoadedOnce;

--- a/ViewModels/DashboardViewModel.cs
+++ b/ViewModels/DashboardViewModel.cs
@@ -43,14 +43,14 @@ namespace FlockForge.ViewModels
         public DashboardViewModel()
         {
             // Text-only Afrikaans tiles
-            Features.Add(new FeatureItem("Profiel",  CreateNav("//profile")));
-            Features.Add(new FeatureItem("My Plase", CreateNav("//farms")));
-            Features.Add(new FeatureItem("Groepe",   CreateNav("//groups")));
-            Features.Add(new FeatureItem("Teel",     CreateNav("//breeding")));
-            Features.Add(new FeatureItem("Skandering (Dragtigheid)", CreateNav("//scanning")));
-            Features.Add(new FeatureItem("Lammering", CreateNav("//lambing")));
-            Features.Add(new FeatureItem("Speen",     CreateNav("//weaning")));
-            Features.Add(new FeatureItem("Verslae",   CreateNav("//reports")));
+            Features.Add(new FeatureItem("Profiel",  CreateNav("profile")));
+            Features.Add(new FeatureItem("My Plase", CreateNav("farms")));
+            Features.Add(new FeatureItem("Groepe",   CreateNav("groups")));
+            Features.Add(new FeatureItem("Teel",     CreateNav("breeding")));
+            Features.Add(new FeatureItem("Skandering (Dragtigheid)", CreateNav("scanning")));
+            Features.Add(new FeatureItem("Lammering", CreateNav("lambing")));
+            Features.Add(new FeatureItem("Speen",     CreateNav("weaning")));
+            Features.Add(new FeatureItem("Verslae",   CreateNav("reports")));
 
             UpdateConnectivityLabel(); // one-shot; no timers/subscriptions
         }

--- a/Views/Pages/BreedingPage.xaml
+++ b/Views/Pages/BreedingPage.xaml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="FlockForge.Views.Pages.BreedingPage"
+             Title="Breeding">
+    <Grid Style="{StaticResource GF.Grid}">
+        <Label Text="Breeding Page" Style="{StaticResource GF.LabelBase}" />
+    </Grid>
+</ContentPage>
+

--- a/Views/Pages/BreedingPage.xaml.cs
+++ b/Views/Pages/BreedingPage.xaml.cs
@@ -1,0 +1,12 @@
+using Microsoft.Maui.Controls;
+
+namespace FlockForge.Views.Pages;
+
+public partial class BreedingPage : ContentPage
+{
+    public BreedingPage()
+    {
+        InitializeComponent();
+    }
+}
+

--- a/Views/Pages/LambingPage.xaml
+++ b/Views/Pages/LambingPage.xaml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="FlockForge.Views.Pages.LambingPage"
+             Title="Lambing">
+    <Grid Style="{StaticResource GF.Grid}">
+        <Label Text="Lambing Page" Style="{StaticResource GF.LabelBase}" />
+    </Grid>
+</ContentPage>
+

--- a/Views/Pages/LambingPage.xaml.cs
+++ b/Views/Pages/LambingPage.xaml.cs
@@ -1,0 +1,12 @@
+using Microsoft.Maui.Controls;
+
+namespace FlockForge.Views.Pages;
+
+public partial class LambingPage : ContentPage
+{
+    public LambingPage()
+    {
+        InitializeComponent();
+    }
+}
+

--- a/Views/Pages/ReportsPage.xaml
+++ b/Views/Pages/ReportsPage.xaml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="FlockForge.Views.Pages.ReportsPage"
+             Title="Reports">
+    <Grid Style="{StaticResource GF.Grid}">
+        <Label Text="Reports Page" Style="{StaticResource GF.LabelBase}" />
+    </Grid>
+</ContentPage>
+

--- a/Views/Pages/ReportsPage.xaml.cs
+++ b/Views/Pages/ReportsPage.xaml.cs
@@ -1,0 +1,12 @@
+using Microsoft.Maui.Controls;
+
+namespace FlockForge.Views.Pages;
+
+public partial class ReportsPage : ContentPage
+{
+    public ReportsPage()
+    {
+        InitializeComponent();
+    }
+}
+

--- a/Views/Pages/ScanningPage.xaml
+++ b/Views/Pages/ScanningPage.xaml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="FlockForge.Views.Pages.ScanningPage"
+             Title="Scanning">
+    <Grid Style="{StaticResource GF.Grid}">
+        <Label Text="Scanning Page" Style="{StaticResource GF.LabelBase}" />
+    </Grid>
+</ContentPage>
+

--- a/Views/Pages/ScanningPage.xaml.cs
+++ b/Views/Pages/ScanningPage.xaml.cs
@@ -1,0 +1,12 @@
+using Microsoft.Maui.Controls;
+
+namespace FlockForge.Views.Pages;
+
+public partial class ScanningPage : ContentPage
+{
+    public ScanningPage()
+    {
+        InitializeComponent();
+    }
+}
+

--- a/Views/Pages/WeaningPage.xaml
+++ b/Views/Pages/WeaningPage.xaml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="FlockForge.Views.Pages.WeaningPage"
+             Title="Weaning">
+    <Grid Style="{StaticResource GF.Grid}">
+        <Label Text="Weaning Page" Style="{StaticResource GF.LabelBase}" />
+    </Grid>
+</ContentPage>
+

--- a/Views/Pages/WeaningPage.xaml.cs
+++ b/Views/Pages/WeaningPage.xaml.cs
@@ -1,0 +1,12 @@
+using Microsoft.Maui.Controls;
+
+namespace FlockForge.Views.Pages;
+
+public partial class WeaningPage : ContentPage
+{
+    public WeaningPage()
+    {
+        InitializeComponent();
+    }
+}
+


### PR DESCRIPTION
## Summary
- Use relative route names in dashboard feature navigation
- Register shell routes for profile, farms, groups and future feature pages
- Add placeholder pages for breeding, scanning, lambing, weaning and reports

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden when attempting to install .NET SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68a59e41219c832eab4011f0bcc6131e