### PR TITLE
Ensure login and register routes are registered

### DIFF
--- a/AppShell.xaml.cs
+++ b/AppShell.xaml.cs
@@ -3,6 +3,7 @@ using System;
 using System.Reactive.Disposables;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using System.Linq;
 using FlockForge.Core.Interfaces;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui;                    // HandlerChangingEventArgs
@@ -40,16 +41,26 @@ public partial class AppShell : Shell
         _authService = authService;
         _logger = logger;
 
-        Routing.RegisterRoute("profile", typeof(ProfilePage));
-        Routing.RegisterRoute("settings", typeof(SettingsPage));
-        Routing.RegisterRoute("login", typeof(LoginPage));
-        Routing.RegisterRoute("farms", typeof(FarmsPage));
-        Routing.RegisterRoute("groups", typeof(GroupsPage));
-        Routing.RegisterRoute("breeding", typeof(BreedingPage));
-        Routing.RegisterRoute("scanning", typeof(ScanningPage));
-        Routing.RegisterRoute("lambing", typeof(LambingPage));
-        Routing.RegisterRoute("weaning", typeof(WeaningPage));
-        Routing.RegisterRoute("reports", typeof(ReportsPage));
+        var regs = Routing.GetRegisteredRoutes().ToHashSet();
+        void Reg(string route, Type pageType)
+        {
+            if (!regs.Contains(route))
+                Routing.RegisterRoute(route, pageType);
+        }
+
+        Reg("profile", typeof(ProfilePage));
+        Reg("settings", typeof(SettingsPage));
+        Reg("farms", typeof(FarmsPage));
+        Reg("groups", typeof(GroupsPage));
+        Reg("breeding", typeof(BreedingPage));
+        Reg("scanning", typeof(ScanningPage));
+        Reg("lambing", typeof(LambingPage));
+        Reg("weaning", typeof(WeaningPage));
+        Reg("reports", typeof(ReportsPage));
+
+        // NEW: auth routes (keeps login/register reachable)
+        Reg("login", typeof(LoginPage));
+        Reg("register", typeof(RegisterPage));
 
         // Wire events once
         Loaded += OnLoadedOnce;

--- a/AppShell.xaml.cs
+++ b/AppShell.xaml.cs
@@ -3,7 +3,6 @@ using System;
 using System.Reactive.Disposables;
 using System.Threading.Tasks;
 using System.Windows.Input;
-using System.Linq;
 using FlockForge.Core.Interfaces;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui;                    // HandlerChangingEventArgs
@@ -25,6 +24,9 @@ public partial class AppShell : Shell
 
     public AppShell(IAuthenticationService authService, ILogger<AppShell> logger)
     {
+        _authService = authService;
+        _logger = logger;
+
         GoToCommand = new Command<string>(async route =>
         {
             try
@@ -38,14 +40,11 @@ public partial class AppShell : Shell
         });
 
         InitializeComponent();
-        _authService = authService;
-        _logger = logger;
 
-        var regs = Routing.GetRegisteredRoutes().ToHashSet();
         void Reg(string route, Type pageType)
         {
-            if (!regs.Contains(route))
-                Routing.RegisterRoute(route, pageType);
+            try { Routing.RegisterRoute(route, pageType); }
+            catch (ArgumentException) { }
         }
 
         Reg("profile", typeof(ProfilePage));


### PR DESCRIPTION
## Summary
- avoid duplicate shell route registrations by using a helper method
- ensure login and register pages are registered so auth pages are always reachable

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a955c65c832e8be589177a932f67